### PR TITLE
RTDT-1889 Rosbag recording process error

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -120,6 +120,9 @@ class RecordVerb(VerbExtension):
         parser.add_argument(
             '--qos-profile-overrides-path', type=FileType('r'),
             help='Path to a yaml file defining overrides of the QoS profile for specific topics.')
+        parser.add_argument(
+            '--timeout-for-delay', type=int, default=90,
+            help='Timeout to stop auto-discovery. By default %(default)d seconds.')
 
         # Core config
         parser.add_argument(


### PR DESCRIPTION
Reason:
Error while running
`ros2 bag record -a --storage-preset-profile zstd_small -s mcap`
![image](https://github.com/user-attachments/assets/a485d5e3-4d06-49ea-99f0-4b69c25e9416)

Solution:
added argument `--timeout-for-delay` with default value 90 seconds.
![RTDT1889(result)](https://github.com/user-attachments/assets/1d8ba356-4048-48b9-be78-e36bbb8ce5b9)

Documentation: https://coda.io/d/_dc9JA2PQkg2/Record-and-Replay-Tracking-Data_suiA0#_luats